### PR TITLE
Add SonarQube integration and coverage badge to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "conventionalCommits.scopes": [
+        "server",
+        "config"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=whaagmans_meeting-costs-calculator-api&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=whaagmans_meeting-costs-calculator-api)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=whaagmans_meeting-costs-calculator-api&metric=bugs)](https://sonarcloud.io/summary/new_code?id=whaagmans_meeting-costs-calculator-api)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=whaagmans_meeting-costs-calculator-api&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=whaagmans_meeting-costs-calculator-api)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=whaagmans_meeting-costs-calculator-api&metric=coverage)](https://sonarcloud.io/summary/new_code?id=whaagmans_meeting-costs-calculator-api)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=whaagmans_meeting-costs-calculator-api&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=whaagmans_meeting-costs-calculator-api)
 
 ## 📢 Overview

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=whaagmans_meeting-costs-calculator-api
+sonar.organization=redeamer
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=meeting-costs-calculator-api
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Introduce a GitHub Actions workflow for SonarQube scanning on pushes and pull requests, along with a project configuration file for code quality analysis. Enhance the README with a coverage badge for improved visibility of test coverage.