### PR TITLE
Fix e2e test expectation

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -20,6 +20,8 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect({
+        message: 'Welcome to the Meeting Costs Calculator API',
+      });
   });
 });


### PR DESCRIPTION
## Summary
- correct e2e test to expect API welcome message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fa4d7e5483258185fc603c6be380